### PR TITLE
feat: add Seven Chain (eip155-70007)

### DIFF
--- a/chains/eip155-70007.json
+++ b/chains/eip155-70007.json
@@ -1,0 +1,21 @@
+{
+  "did": "did:ethr:eip155-70007",
+  "name": "Seven Chain",
+  "network": "eip155-70007",
+  "interface": "evm",
+  "coins": [
+    {
+      "name": "SEVEN",
+      "symbol": "SEVEN",
+      "denom": "wei",
+      "granularity": 18
+    }
+  ],
+  "rpc": [
+    "https://theseven.meme/api/seven-chain/jsonrpc"
+  ],
+  "custom": {
+    "chainId": 70007,
+    "networkId": 70007
+  }
+}


### PR DESCRIPTION
## Seven Chain (eip155-70007)

Adds Seven Chain — the on-chain settlement layer for [TheSeven.meme](https://theseven.meme) perpetual futures exchange.

- **Chain ID:** 70007
- **Network:** eip155-70007
- **Interface:** evm
- **Native currency:** SEVEN (18 decimals)
- **RPC:** https://theseven.meme/api/seven-chain/jsonrpc
- **Purpose:** Immutable on-chain recording of perpetual futures trades